### PR TITLE
Use default width if there is no console

### DIFF
--- a/progress_bar.cpp
+++ b/progress_bar.cpp
@@ -1,5 +1,7 @@
 #include "progress_bar.hpp"
 
+const int ProgressBar::DEFAULT_WIDTH = 80;
+
 ProgressBar::ProgressBar() {}
 
 ProgressBar::ProgressBar(unsigned long n_, const char* description_, std::ostream& out_){
@@ -35,15 +37,18 @@ int ProgressBar::GetConsoleWidth(){
 
     int width;
 
-	#ifdef _WINDOWS
-		CONSOLE_SCREEN_BUFFER_INFO csbi;
-		GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
-		width = csbi.srWindow.Right - csbi.srWindow.Left;
-	#else
-		struct winsize win;
-		ioctl(0, TIOCGWINSZ, &win);
-        width = win.ws_col;
-	#endif
+    #ifdef _WINDOWS
+        CONSOLE_SCREEN_BUFFER_INFO csbi;
+        GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
+        width = csbi.srWindow.Right - csbi.srWindow.Left;
+    #else
+        struct winsize win;
+        if (ioctl(0, TIOCGWINSZ, &win) == -1) {
+            width = DEFAULT_WIDTH;
+        } else {
+            width = win.ws_col;
+        }
+    #endif
 
     return width;
 }

--- a/progress_bar.hpp
+++ b/progress_bar.hpp
@@ -18,6 +18,8 @@ class ProgressBar{
 
 public: 
 
+    const static int DEFAULT_WIDTH;
+
     ProgressBar();
     ProgressBar(unsigned long n_, const char *description_="", std::ostream& out_=std::cerr);
 


### PR DESCRIPTION
If we use `ProgressBar` in a process without a console (e.g. in jobs run with GNU Parallel), the `ioctl()` call in `ProgressBar::GetConsoleWidth()` returns an error. The progress bar will then use whatever garbage happened to be in the memory location of `win.ws_col` as console width, often creating ridiculously massive progress bars. This PR detects the error and selects a reasonable default width.